### PR TITLE
patch LaTeX installation

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,0 +1,18 @@
+name: Docker CI
+
+on: [push]
+#  release:
+#    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        #      - name: Login to DockerHub Registry
+        #        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${GITHUB_ACTOR} --password-stdin docker.pkg.github.com
+      - name: Build the tagged Docker image
+        run: make build 
+        #      - name: Push the tagged Docker image
+        #run: docker push docker.pkg.github.com/noamross/rocker-versioned2/r-ver:3.6.2
+

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 DOCKERFILES=$(wildcard dockerfiles/Dockerfile*)
 PARTIALS=$(wildcard partials/*.partial)
 
+TAG=3.6.2-gpu
+REGISTRY=docker.pkg.github.com
+
 .PHONY: local_versions images
 dockerfiles: $(DOCKERFILES)
 all: dockerfiles images
@@ -19,12 +22,12 @@ images:
 
 
 build: 
-	docker build -t rocker/r-ver:3.6.2-gpu -f dockerfiles/Dockerfile_r-ver_3.6.2-gpu .
-	docker build -t rocker/rstudio:3.6.2-gpu -f dockerfiles/Dockerfile_rstudio_3.6.2-gpu .
-	docker build -t rocker/tidyverse:3.6.2-gpu -f dockerfiles/Dockerfile_tidyverse_3.6.2-gpu .
-	docker build -t rocker/verse:3.6.2-gpu -f dockerfiles/Dockerfile_verse_3.6.2-gpu .
-	docker build -t rocker/geospatial:3.6.2-gpu -f dockerfiles/Dockerfile_geospatial_3.6.2-gpu .
-	docker build -t rocker/ml:3.6.2-gpu -f dockerfiles/Dockerfile_ml_3.6.2-gpu .
+	docker build -t rocker/r-ver:${TAG} -f dockerfiles/Dockerfile_r-ver_${TAG} .
+	docker build -t rocker/rstudio:${TAG} -f dockerfiles/Dockerfile_rstudio_${TAG} .
+	docker build -t rocker/tidyverse:${TAG} -f dockerfiles/Dockerfile_tidyverse_${TAG} .
+	docker build -t rocker/verse:${TAG} -f dockerfiles/Dockerfile_verse_${TAG} .
+	docker build -t rocker/geospatial:${TAG} -f dockerfiles/Dockerfile_geospatial_${TAG} .
+	docker build -t rocker/ml:${TAG} -f dockerfiles/Dockerfile_ml_${TAG} .
 
 
 clean:

--- a/dockerfiles/Dockerfile_geospatial_3.6.2
+++ b/dockerfiles/Dockerfile_geospatial_3.6.2
@@ -4,6 +4,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
+COPY scripts/install_geospatial.sh /rocker_scripts/install_geospatial.sh
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_geospatial_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_geospatial_3.6.2-gpu
@@ -4,6 +4,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
+COPY scripts/install_geospatial.sh /rocker_scripts/install_geospatial.sh
 RUN /rocker_scripts/install_geospatial.sh
 
 

--- a/dockerfiles/Dockerfile_ml_3.6.2
+++ b/dockerfiles/Dockerfile_ml_3.6.2
@@ -7,7 +7,9 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV PYTHON_VENV_PATH=/opt/venv 
 ENV RETICULATE_PYTHON_ENV=$PYTHON_VENV_PATH
 ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}
+COPY scripts/install_python.sh /rocker_scripts/install_python.sh
 RUN . /rocker_scripts/install_python.sh
+COPY scripts/install_tensorflow.sh /rocker_scripts/install_tensorflow.sh
 ENV TENSORFLOW_VERSION=default
 RUN . /rocker_scripts/install_tensorflow.sh
 

--- a/dockerfiles/Dockerfile_ml_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_ml_3.6.2-gpu
@@ -7,7 +7,9 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV PYTHON_VENV_PATH=/opt/venv 
 ENV RETICULATE_PYTHON_ENV=$PYTHON_VENV_PATH
 ENV PATH=${PYTHON_VENV_PATH}/bin:${PATH}
+COPY scripts/install_python.sh /rocker_scripts/install_python.sh
 RUN . /rocker_scripts/install_python.sh
+COPY scripts/install_tensorflow.sh /rocker_scripts/install_tensorflow.sh
 ENV TENSORFLOW_VERSION=gpu
 RUN . /rocker_scripts/install_tensorflow.sh
 

--- a/dockerfiles/Dockerfile_r-ver_3.6.1
+++ b/dockerfiles/Dockerfile_r-ver_3.6.1
@@ -5,7 +5,6 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
-COPY scripts /rocker_scripts
 
 # Set system environmetnal variables
 ENV TERM=xterm
@@ -21,5 +20,6 @@ ENV R_VERSION=3.6.1
 ENV MRAN=2019-12-12
 ENV CRAN=https://mran.microsoft.com/snapshot/2019-12-12
 
+COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 RUN /rocker_scripts/install_R.sh
 CMD "R"

--- a/dockerfiles/Dockerfile_r-ver_3.6.2
+++ b/dockerfiles/Dockerfile_r-ver_3.6.2
@@ -5,7 +5,6 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
-COPY scripts /rocker_scripts
 
 # Set system environmetnal variables
 ENV TERM=xterm
@@ -20,5 +19,6 @@ ENV R_VERSION=3.6.2
 
 ENV CRAN=https://cran.rstudio.com
 
+COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 RUN /rocker_scripts/install_R.sh
 CMD "R"

--- a/dockerfiles/Dockerfile_r-ver_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_r-ver_3.6.2-gpu
@@ -5,7 +5,6 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
-COPY scripts /rocker_scripts
 
 # Set system environmetnal variables
 ENV TERM=xterm
@@ -20,12 +19,14 @@ ENV R_VERSION=3.6.2
 
 ENV CRAN=https://cran.rstudio.com
 
+COPY scripts/install_R.sh /rocker_scripts/install_R.sh
 RUN /rocker_scripts/install_R.sh
 ## Use Configure CUDA for R, use NVidia libs for BLAS
 ENV CUDA_HOME=/usr/local/cuda
 ENV PATH=$PATH:$CUDA_HOME/bin
 ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64/libnvblas.so:$LD_LIBRARY_PATH:$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64
 ENV NVBLAS_CONFIG_FILE=/etc/nvblas.conf
+COPY scripts/config_R_cuda.sh /rocker_scripts/config_R_cuda.sh
 RUN . /rocker_scripts/config_R_cuda.sh
 
 

--- a/dockerfiles/Dockerfile_rstudio_3.6.1
+++ b/dockerfiles/Dockerfile_rstudio_3.6.1
@@ -8,11 +8,16 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 
+COPY scripts/install_s6init.sh /rocker_scripts/install_s6init.sh
+COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh
+COPY scripts/default_user.sh /rocker_scripts/default_user.sh
 RUN /rocker_scripts/install_rstudio.sh
 
+COPY scripts/install_pandoc.sh /rocker_scripts/install_pandoc.sh
 RUN /rocker_scripts/install_pandoc.sh
 
 ## Arguably this should be created by install_s6init.sh
+COPY scripts/userconf.sh /rocker_scripts/userconf.sh
 RUN cp /rocker_scripts/userconf.sh /etc/cont-init.d/userconf
 CMD "/init"
 EXPOSE 8787

--- a/dockerfiles/Dockerfile_rstudio_3.6.2
+++ b/dockerfiles/Dockerfile_rstudio_3.6.2
@@ -8,11 +8,16 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 
+COPY scripts/install_s6init.sh /rocker_scripts/install_s6init.sh
+COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh
+COPY scripts/default_user.sh /rocker_scripts/default_user.sh
 RUN /rocker_scripts/install_rstudio.sh
 
+COPY scripts/install_pandoc.sh /rocker_scripts/install_pandoc.sh
 RUN /rocker_scripts/install_pandoc.sh
 
 ## Arguably this should be created by install_s6init.sh
+COPY scripts/userconf.sh /rocker_scripts/userconf.sh
 RUN cp /rocker_scripts/userconf.sh /etc/cont-init.d/userconf
 CMD "/init"
 EXPOSE 8787

--- a/dockerfiles/Dockerfile_rstudio_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_rstudio_3.6.2-gpu
@@ -8,11 +8,16 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV S6_VERSION=v1.21.7.0
 ENV RSTUDIO_VERSION=latest
 
+COPY scripts/install_s6init.sh /rocker_scripts/install_s6init.sh
+COPY scripts/install_rstudio.sh /rocker_scripts/install_rstudio.sh
+COPY scripts/default_user.sh /rocker_scripts/default_user.sh
 RUN /rocker_scripts/install_rstudio.sh
 
+COPY scripts/install_pandoc.sh /rocker_scripts/install_pandoc.sh
 RUN /rocker_scripts/install_pandoc.sh
 
 ## Arguably this should be created by install_s6init.sh
+COPY scripts/userconf.sh /rocker_scripts/userconf.sh
 RUN cp /rocker_scripts/userconf.sh /etc/cont-init.d/userconf
 CMD "/init"
 EXPOSE 8787

--- a/dockerfiles/Dockerfile_shiny-verse_3.6.1
+++ b/dockerfiles/Dockerfile_shiny-verse_3.6.1
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_shiny-verse_3.6.1
+++ b/dockerfiles/Dockerfile_shiny-verse_3.6.1
@@ -1,4 +1,4 @@
-FROM rocker/shiny:3.6.1
+FROM rocker/shiny:3.6.2
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \

--- a/dockerfiles/Dockerfile_shiny-verse_3.6.2
+++ b/dockerfiles/Dockerfile_shiny-verse_3.6.2
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_shiny_3.6.1
+++ b/dockerfiles/Dockerfile_shiny_3.6.1
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:3.6.1
+FROM rocker/r-ver:3.6.2
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker-versioned" \

--- a/dockerfiles/Dockerfile_shiny_3.6.1
+++ b/dockerfiles/Dockerfile_shiny_3.6.1
@@ -7,6 +7,9 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest
 
+COPY scripts/install_pandoc.sh /rocker_scripts/install_pandoc.sh
+COPY scripts/install_s6init.sh /rocker_scripts/install_s6init.sh
+COPY scripts/install_shiny_server.sh /rocker_scripts/install_shiny_server.sh
 RUN /rocker_scripts/install_shiny_server.sh
 CMD "/init"
 EXPOSE 3838

--- a/dockerfiles/Dockerfile_shiny_3.6.2
+++ b/dockerfiles/Dockerfile_shiny_3.6.2
@@ -7,6 +7,9 @@ LABEL org.label-schema.license="GPL-2.0" \
 ENV S6_VERSION=v1.21.7.0
 ENV SHINY_SERVER_VERSION=latest
 
+COPY scripts/install_pandoc.sh /rocker_scripts/install_pandoc.sh
+COPY scripts/install_s6init.sh /rocker_scripts/install_s6init.sh
+COPY scripts/install_shiny_server.sh /rocker_scripts/install_shiny_server.sh
 RUN /rocker_scripts/install_shiny_server.sh
 CMD "/init"
 EXPOSE 3838

--- a/dockerfiles/Dockerfile_tidyverse_3.6.2
+++ b/dockerfiles/Dockerfile_tidyverse_3.6.2
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_tidyverse_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_tidyverse_3.6.2-gpu
@@ -5,6 +5,7 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+COPY scripts/install_tidyverse.sh /rocker_scripts/install_tidyverse.sh
 RUN /rocker_scripts/install_tidyverse.sh
 
 

--- a/dockerfiles/Dockerfile_verse_3.6.2
+++ b/dockerfiles/Dockerfile_verse_3.6.2
@@ -8,6 +8,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 COPY scripts/install_texlive.sh /rocker_scripts/install_texlive.sh
 
+ENV CTAN_REPO=${CTAN_REPO:-https://www.texlive.info/tlnet-archive/2019/02/27/tlnet}
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/Dockerfile_verse_3.6.2
+++ b/dockerfiles/Dockerfile_verse_3.6.2
@@ -5,6 +5,8 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
+ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 
 

--- a/dockerfiles/Dockerfile_verse_3.6.2
+++ b/dockerfiles/Dockerfile_verse_3.6.2
@@ -6,7 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
+COPY scripts/install_texlive.sh /rocker_scripts/install_texlive.sh
 
+ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 

--- a/dockerfiles/Dockerfile_verse_3.6.2
+++ b/dockerfiles/Dockerfile_verse_3.6.2
@@ -5,8 +5,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 
-ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
+ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 
 

--- a/dockerfiles/Dockerfile_verse_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_verse_3.6.2-gpu
@@ -8,6 +8,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 COPY scripts/install_texlive.sh /rocker_scripts/install_texlive.sh
 
+ENV CTAN_REPO=${CTAN_REPO:-https://www.texlive.info/tlnet-archive/2019/02/27/tlnet}
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh

--- a/dockerfiles/Dockerfile_verse_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_verse_3.6.2-gpu
@@ -5,6 +5,8 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+
+ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 
 

--- a/dockerfiles/Dockerfile_verse_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_verse_3.6.2-gpu
@@ -6,7 +6,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
+COPY scripts/install_texlive.sh /rocker_scripts/install_texlive.sh
 
+ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 

--- a/dockerfiles/Dockerfile_verse_3.6.2-gpu
+++ b/dockerfiles/Dockerfile_verse_3.6.2-gpu
@@ -5,8 +5,9 @@ LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vendor="Rocker Project" \
       maintainer="Carl Boettiger <cboettig@ropensci.org>"
 
+COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 
-ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
+ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 
 

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -8,7 +8,7 @@ images_list <- c(
   jsonlite::read_json("versions-bionic.json"),
   jsonlite::read_json("versions-cuda.json")
 )
-ROCKER_DEV_WORKFLOW = Sys.getenv("ROCKER_DEV_WORKFLOW", "0")
+ROCKER_DEV_WORKFLOW = Sys.getenv("ROCKER_DEV_WORKFLOW", "1")
 #images_list <- split(
 #  versions_grid, 
 #  paste(versions_grid$ROCKER_IMAGE, versions_grid$ROCKER_TAG, sep = "_")

--- a/make-dockerfiles.R
+++ b/make-dockerfiles.R
@@ -8,7 +8,7 @@ images_list <- c(
   jsonlite::read_json("versions-bionic.json"),
   jsonlite::read_json("versions-cuda.json")
 )
-ROCKER_DEV_WORKFLOW = Sys.getenv("ROCKER_DEV_WORKFLOW", "1")
+ROCKER_DEV_WORKFLOW = Sys.getenv("ROCKER_DEV_WORKFLOW", "0")
 #images_list <- split(
 #  versions_grid, 
 #  paste(versions_grid$ROCKER_IMAGE, versions_grid$ROCKER_TAG, sep = "_")

--- a/partials/Dockerfile.verse.partial
+++ b/partials/Dockerfile.verse.partial
@@ -2,6 +2,8 @@
 {{#ROCKER_DEV_WORKFLOW}}
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 {{/ROCKER_DEV_WORKFLOW}}
+
+ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 
 

--- a/partials/Dockerfile.verse.partial
+++ b/partials/Dockerfile.verse.partial
@@ -3,7 +3,7 @@
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 {{/ROCKER_DEV_WORKFLOW}}
 
-ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
+ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 
 

--- a/partials/Dockerfile.verse.partial
+++ b/partials/Dockerfile.verse.partial
@@ -4,6 +4,7 @@ COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
 COPY scripts/install_texlive.sh /rocker_scripts/install_texlive.sh
 {{/ROCKER_DEV_WORKFLOW}}
 
+ENV CTAN_REPO=${CTAN_REPO:-https://www.texlive.info/tlnet-archive/2019/02/27/tlnet}
 ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh

--- a/partials/Dockerfile.verse.partial
+++ b/partials/Dockerfile.verse.partial
@@ -1,8 +1,10 @@
 
 {{#ROCKER_DEV_WORKFLOW}}
 COPY scripts/install_verse.sh /rocker_scripts/install_verse.sh
+COPY scripts/install_texlive.sh /rocker_scripts/install_texlive.sh
 {{/ROCKER_DEV_WORKFLOW}}
 
+ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
 ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 RUN /rocker_scripts/install_verse.sh
 

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,5 +1,5 @@
 echo 'selected_scheme scheme-infraonly
-TEXDIR /opt/texlive
+TEXDIR /usr/local/texlive
 TEXMFCONFIG /opt/texlive/texmf-config
 TEXMFHOME  /opt/texlive/texmf
 TEXMFLOCAL /opt/texlive/texmf-local
@@ -25,4 +25,9 @@ tlmgr install latex-bin luatex xetex
 chown -R root:staff /opt/texlive
 chmod -R g+w /opt/texlive
 chmod -R g+wx /opt/texlive/bin
+
+
+chown -R root:staff /usr/local/texlive
+chmod -R g+w /usr/local/texlive
+
 

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,14 +1,15 @@
-echo 'selected_scheme scheme-minimal
-TEXDIR /usr/local/texlive
-TEXMFCONFIG ~/.texlive/texmf-config
-TEXMFHOME ~/texmf
-TEXMFLOCAL /usr/local/texlive/texmf-local
-TEXMFSYSCONFIG /usr/local/texlive/texmf-config
-TEXMFSYSVAR /usr/local/texlive/texmf-var
-TEXMFVAR ~/.texlive/texmf-var
+echo 'selected_scheme scheme-infraonly
+TEXDIR /opt/texlive
+TEXMFCONFIG /opt/texlive/texmf-config
+TEXMFHOME  /opt/texlive/texmf
+TEXMFLOCAL /opt/texlive/texmf-local
+TEXMFSYSCONFIG /opt/texlive/texmf-config
+TEXMFSYSVAR /opt/texlive/texmf-var
+TEXMFVAR /opt/texlive/texmf-var
 option_doc 0
 option_src 0' > /tmp/texlive-profile.txt
 
+mkdir -p /opt/texlive
 # set up packages
 apt-get update && apt-get -y install wget perl xzdec 
 wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz 
@@ -16,8 +17,12 @@ tar -xzf install-tl-unx.tar.gz
 install-tl-20*/install-tl --profile=/tmp/texlive-profile.txt && \
     rm -rf install-tl-*
 
-# ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
+# ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
 
 tlmgr update --self
+tlmgr install latex-bin luatex xetex
 
+chown -R root:staff /opt/texlive
+chmod -R g+w /opt/texlive
+chmod -R g+wx /opt/texlive/bin
 

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -1,0 +1,23 @@
+echo 'selected_scheme scheme-minimal
+TEXDIR /usr/local/texlive
+TEXMFCONFIG ~/.texlive/texmf-config
+TEXMFHOME ~/texmf
+TEXMFLOCAL /usr/local/texlive/texmf-local
+TEXMFSYSCONFIG /usr/local/texlive/texmf-config
+TEXMFSYSVAR /usr/local/texlive/texmf-var
+TEXMFVAR ~/.texlive/texmf-var
+option_doc 0
+option_src 0' > /tmp/texlive-profile.txt
+
+# set up packages
+apt-get update && apt-get -y install wget perl xzdec 
+wget http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz 
+tar -xzf install-tl-unx.tar.gz 
+install-tl-20*/install-tl --profile=/tmp/texlive-profile.txt && \
+    rm -rf install-tl-*
+
+# ENV PATH=/usr/local/texlive/bin/x86_64-linux:$PATH
+
+tlmgr update --self
+
+

--- a/scripts/install_texlive.sh
+++ b/scripts/install_texlive.sh
@@ -18,9 +18,13 @@ install-tl-20*/install-tl --profile=/tmp/texlive-profile.txt && \
     rm -rf install-tl-*
 
 # ENV PATH=/opt/texlive/bin/x86_64-linux:$PATH
+# ARG CTAN_REPO=${CTAN_REPO:-https://www.texlive.info/tlnet-archive/2019/02/27/tlnet}
+# ENV CTAN_REPO=${CTAN_REPO}
 
 tlmgr update --self
 tlmgr install latex-bin luatex xetex
+tlmgr path add
+
 
 chown -R root:staff /opt/texlive
 chmod -R g+w /opt/texlive

--- a/scripts/install_verse.sh
+++ b/scripts/install_verse.sh
@@ -33,22 +33,10 @@ wget "https://travis-bin.yihui.name/texlive-local.deb" \
 
 install2.r --error -r $CRAN --skipinstalled tinytex
 
-## Admin-based install of TinyTeX:
-wget -qO- \
-    "https://github.com/yihui/tinytex/raw/master/tools/install-unx.sh" | \
-    sh -s - --admin --no-path \
-  && mv ~/.TinyTeX /opt/TinyTeX \
-  && /opt/TinyTeX/bin/*/tlmgr path add \
-  && tlmgr install metafont mfware inconsolata tex ae parskip listings \
-  && tlmgr path add \
-  && Rscript -e "tinytex::r_texmf()" \
-  && chown -R root:staff /opt/TinyTeX \
-  && chown -R root:staff ${R_HOME}/site-library \
-  && chmod -R g+w /opt/TinyTeX \
-  && chmod -R g+wx /opt/TinyTeX/bin \
-  && echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
- 
+/rocker_scripts/install_texlive.sh
 
+echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
+ 
 install2.r --error --deps TRUE -r $CRAN --skipinstalled \
     blogdown bookdown rticles rmdshower rJava
 

--- a/versions-bionic.json
+++ b/versions-bionic.json
@@ -79,7 +79,7 @@
   {
     "ROCKER_IMAGE": "shiny",
     "ROCKER_TAG": "3.6.1",
-    "FROM_IMAGE": "rocker/r-ver:3.6.1",
+    "FROM_IMAGE": "rocker/r-ver:3.6.2",
     "SHINY_SERVER_VERSION": "latest",
     "S6_VERSION": "v1.21.7.0",
     "PARTIAL_DOCKERFILES": "shinyserver",
@@ -99,7 +99,7 @@
   {
     "ROCKER_IMAGE": "shiny-verse",
     "ROCKER_TAG": "3.6.1",
-    "FROM_IMAGE": "rocker/shiny:3.6.1",
+    "FROM_IMAGE": "rocker/shiny:3.6.2",
     "PARTIAL_DOCKERFILES": "tidyverse"
   },
   {


### PR DESCRIPTION
I'm not sure what's up with `tinytex` but the config on the debian-based images does not work on Ubuntu.   The `tinytex` installation scripts are all a little opaque to me, there's a good number of hardwired paths I don't follow.  

It is a pity that ubuntu doesn't package `tlmgr` inside anything smaller than texlive-base (~650 MB unpacked).  Instead, I install texlive directly with the standard `tl_install` script of the texlive team (same thing that tinytex does), but just using the default `scheme-minimal`.  Seems to work though need to test the multi-user case.   